### PR TITLE
bump padpo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ install_requires =
     pogrep==0.1.2
     potodo==0.6.0
     pomerge==0.1.4
-    padpo==0.8.0
+    padpo==0.9.0


### PR DESCRIPTION
BTW, python-docs-fr seems to be using an old `padpo` version that has dependencies issues.